### PR TITLE
update sample app to use aws-sdk v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "license": "MIT-0",
   "dependencies": {
-    "aws-sdk": "^2.657.0",
+    "@aws-sdk/client-dynamodb": "^3.1.0",
     "aws-xray-sdk": "^3.0.0",
     "express": "^4.17.1",
     "mysql": "^2.18.1"


### PR DESCRIPTION
*Issue #, if available:*
Fixes #1

*Description of changes:*

Upgrade sample to show usage of AWS SDK version 3

- Remove AWS SDK v2
- Add DynamoDB client from SDK v3
- Capture client with XRay

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
